### PR TITLE
Added photos

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -49,7 +49,10 @@
       "mcp__Claude_Preview__preview_start",
       "Bash(git checkout *)",
       "Bash(dotnet ef *)",
-      "Bash(xargs cat *)"
+      "Bash(xargs cat *)",
+      "Bash(node \"K:\\\\Code\\\\veille-boisee\\\\frontend\\\\node_modules\\\\.bin\\\\ng\" build --configuration=development)",
+      "Bash(xargs grep *)",
+      "Bash(find /k/Code/veille-boisee/frontend/src/app -type f \\\\\\( -name \"*.ts\" -o -name \"*.html\" \\\\\\) -exec grep -l \"img\\\\|image\\\\|photo\\\\|picture\" {} \\\\;)"
     ]
   }
 }

--- a/backend/src/VeilleBoisee.Api/Controllers/ReportsController.cs
+++ b/backend/src/VeilleBoisee.Api/Controllers/ReportsController.cs
@@ -10,25 +10,58 @@ namespace VeilleBoisee.Api.Controllers;
 [Route("api/[controller]")]
 public sealed class ReportsController : ControllerBase
 {
+    private static readonly HashSet<string> AllowedPhotoMimeTypes =
+        ["image/jpeg", "image/png", "image/webp"];
+    private const long MaxPhotoSizeBytes = 5 * 1024 * 1024;
+
     private readonly IMediator _mediator;
 
     public ReportsController(IMediator mediator) => _mediator = mediator;
 
     [HttpPost]
+    [Consumes("multipart/form-data")]
     [ProducesResponseType(typeof(ReportSubmittedResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
     public async Task<IActionResult> Submit(
-        [FromBody] SubmitReportRequest request,
+        [FromForm] SubmitReportRequest request,
+        IFormFile? photo,
         CancellationToken cancellationToken)
     {
+        Stream? photoStream = null;
+        string? photoMimeType = null;
+
+        if (photo is not null)
+        {
+            if (photo.Length > MaxPhotoSizeBytes)
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Photo too large",
+                    Detail = "La photo ne peut pas dépasser 5 Mo.",
+                    Status = StatusCodes.Status400BadRequest
+                });
+
+            if (!AllowedPhotoMimeTypes.Contains(photo.ContentType))
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Unsupported photo format",
+                    Detail = "Formats acceptés : JPEG, PNG, WebP.",
+                    Status = StatusCodes.Status400BadRequest
+                });
+
+            photoStream = photo.OpenReadStream();
+            photoMimeType = photo.ContentType;
+        }
+
         var command = new SubmitReportCommand(
             request.Latitude,
             request.Longitude,
             request.CommuneInsee,
             request.CommuneName,
             request.Description,
-            request.ContactEmail);
+            request.ContactEmail,
+            photoStream,
+            photoMimeType);
 
         var result = await _mediator.Send(command, cancellationToken);
 
@@ -62,6 +95,20 @@ public sealed class ReportsController : ControllerBase
             _ => StatusCode(StatusCodes.Status500InternalServerError)
         };
     }
+
+    [HttpGet("{id:guid}/photo")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetPhoto(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(new GetReportPhotoQuery(id), cancellationToken);
+
+        if (!result.IsSuccess)
+            return NotFound();
+
+        return File(result.Value.Data, result.Value.MimeType);
+    }
+
     [HttpGet("{id:guid}/status")]
     [ProducesResponseType(typeof(ReportStatusResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/backend/src/VeilleBoisee.Application/Abstractions/IExifStrippingService.cs
+++ b/backend/src/VeilleBoisee.Application/Abstractions/IExifStrippingService.cs
@@ -1,0 +1,6 @@
+namespace VeilleBoisee.Application.Abstractions;
+
+public interface IExifStrippingService
+{
+    Task<byte[]> StripExifAsync(Stream photoStream, CancellationToken cancellationToken);
+}

--- a/backend/src/VeilleBoisee.Application/Reports/Commands/SubmitReport.cs
+++ b/backend/src/VeilleBoisee.Application/Reports/Commands/SubmitReport.cs
@@ -12,7 +12,9 @@ public sealed record SubmitReportCommand(
     string CommuneInsee,
     string CommuneName,
     string Description,
-    string ContactEmail
+    string ContactEmail,
+    Stream? PhotoStream = null,
+    string? PhotoMimeType = null
 ) : IRequest<Result<Guid, SubmitReportError>>;
 
 public enum SubmitReportError
@@ -29,15 +31,18 @@ internal sealed class SubmitReportHandler
     private readonly IReportRepository _repository;
     private readonly IEmailEncryptionService _encryption;
     private readonly IGeographicEnrichmentService _enrichment;
+    private readonly IExifStrippingService _exifStripping;
 
     public SubmitReportHandler(
         IReportRepository repository,
         IEmailEncryptionService encryption,
-        IGeographicEnrichmentService enrichment)
+        IGeographicEnrichmentService enrichment,
+        IExifStrippingService exifStripping)
     {
         _repository = repository;
         _encryption = encryption;
         _enrichment = enrichment;
+        _exifStripping = exifStripping;
     }
 
     public async Task<Result<Guid, SubmitReportError>> Handle(
@@ -62,12 +67,19 @@ internal sealed class SubmitReportHandler
             return SubmitReportError.InvalidContactEmail;
 
         var encryptedEmail = _encryption.Encrypt(emailResult.Value.Value);
+
+        byte[]? photoData = null;
+        if (request.PhotoStream is not null)
+            photoData = await _exifStripping.StripExifAsync(request.PhotoStream, cancellationToken);
+
         var report = Report.Create(
             coordinatesResult.Value,
             codeInseeResult.Value,
             request.CommuneName,
             request.Description,
-            encryptedEmail);
+            encryptedEmail,
+            photoData,
+            request.PhotoMimeType);
 
         await _repository.AddAsync(report, cancellationToken);
 

--- a/backend/src/VeilleBoisee.Application/Reports/Queries/GetReportDetail.cs
+++ b/backend/src/VeilleBoisee.Application/Reports/Queries/GetReportDetail.cs
@@ -26,7 +26,8 @@ public sealed record ReportDetailDto(
     string? ParcelleSection,
     string? ParcelleNumero,
     bool? IsInForest,
-    bool? IsInNatura2000Zone);
+    bool? IsInNatura2000Zone,
+    bool HasPhoto);
 
 internal sealed class GetReportDetailHandler
     : IRequestHandler<GetReportDetailQuery, Result<ReportDetailDto, GetReportDetailError>>
@@ -64,6 +65,7 @@ internal sealed class GetReportDetailHandler
             report.ParcelleSection,
             report.ParcelleNumero,
             report.IsInForest,
-            report.IsInNatura2000Zone);
+            report.IsInNatura2000Zone,
+            report.PhotoData is not null);
     }
 }

--- a/backend/src/VeilleBoisee.Application/Reports/Queries/GetReportPhoto.cs
+++ b/backend/src/VeilleBoisee.Application/Reports/Queries/GetReportPhoto.cs
@@ -1,0 +1,42 @@
+using MediatR;
+using VeilleBoisee.Application.Abstractions;
+using VeilleBoisee.Domain.Common;
+
+namespace VeilleBoisee.Application.Reports.Queries;
+
+public sealed record GetReportPhotoQuery(Guid ReportId)
+    : IRequest<Result<ReportPhotoDto, GetReportPhotoError>>;
+
+public enum GetReportPhotoError
+{
+    NotFound,
+    NoPhoto
+}
+
+public sealed record ReportPhotoDto(byte[] Data, string MimeType);
+
+internal sealed class GetReportPhotoHandler
+    : IRequestHandler<GetReportPhotoQuery, Result<ReportPhotoDto, GetReportPhotoError>>
+{
+    private readonly IReportRepository _repository;
+
+    public GetReportPhotoHandler(IReportRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Result<ReportPhotoDto, GetReportPhotoError>> Handle(
+        GetReportPhotoQuery request,
+        CancellationToken cancellationToken)
+    {
+        var report = await _repository.GetByIdAsync(request.ReportId, cancellationToken);
+
+        if (report is null)
+            return GetReportPhotoError.NotFound;
+
+        if (report.PhotoData is null || report.PhotoMimeType is null)
+            return GetReportPhotoError.NoPhoto;
+
+        return new ReportPhotoDto(report.PhotoData, report.PhotoMimeType);
+    }
+}

--- a/backend/src/VeilleBoisee.Domain/Entities/Report.cs
+++ b/backend/src/VeilleBoisee.Domain/Entities/Report.cs
@@ -28,12 +28,17 @@ public sealed class Report
     public bool? IsInForest { get; private set; }
     public bool? IsInNatura2000Zone { get; private set; }
 
+    public byte[]? PhotoData { get; private set; }
+    public string? PhotoMimeType { get; private set; }
+
     public static Report Create(
         Coordinates location,
         CodeInsee communeInsee,
         string communeName,
         string description,
-        string encryptedContactEmail)
+        string encryptedContactEmail,
+        byte[]? photoData = null,
+        string? photoMimeType = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(communeName);
         ArgumentException.ThrowIfNullOrWhiteSpace(description);
@@ -49,7 +54,9 @@ public sealed class Report
             Description = description,
             EncryptedContactEmail = encryptedContactEmail,
             Status = ReportStatus.Pending,
-            SubmittedAt = DateTimeOffset.UtcNow
+            SubmittedAt = DateTimeOffset.UtcNow,
+            PhotoData = photoData,
+            PhotoMimeType = photoMimeType
         };
     }
 

--- a/backend/src/VeilleBoisee.Infrastructure/DependencyInjection.cs
+++ b/backend/src/VeilleBoisee.Infrastructure/DependencyInjection.cs
@@ -8,6 +8,7 @@ using VeilleBoisee.Infrastructure.Geocoding;
 using VeilleBoisee.Infrastructure.Enrichment;
 using VeilleBoisee.Infrastructure.Persistence;
 using VeilleBoisee.Infrastructure.Persistence.Repositories;
+using VeilleBoisee.Infrastructure.Photos;
 using VeilleBoisee.Infrastructure.Security;
 
 namespace VeilleBoisee.Infrastructure;
@@ -72,6 +73,8 @@ public static class DependencyInjection
             });
 
         services.AddTransient<IGeographicEnrichmentService, GeographicEnrichmentService>();
+
+        services.AddSingleton<IExifStrippingService, ImageSharpExifStrippingService>();
 
         return services;
     }

--- a/backend/src/VeilleBoisee.Infrastructure/Migrations/20260422075741_AddPhotoToReport.Designer.cs
+++ b/backend/src/VeilleBoisee.Infrastructure/Migrations/20260422075741_AddPhotoToReport.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VeilleBoisee.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using VeilleBoisee.Infrastructure.Persistence;
 namespace VeilleBoisee.Infrastructure.Migrations
 {
     [DbContext(typeof(VeilleBoiseeDbContext))]
-    partial class VeilleBoiseeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422075741_AddPhotoToReport")]
+    partial class AddPhotoToReport
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/VeilleBoisee.Infrastructure/Migrations/20260422075741_AddPhotoToReport.cs
+++ b/backend/src/VeilleBoisee.Infrastructure/Migrations/20260422075741_AddPhotoToReport.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VeilleBoisee.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPhotoToReport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte[]>(
+                name: "PhotoData",
+                table: "Reports",
+                type: "varbinary(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PhotoMimeType",
+                table: "Reports",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PhotoData",
+                table: "Reports");
+
+            migrationBuilder.DropColumn(
+                name: "PhotoMimeType",
+                table: "Reports");
+        }
+    }
+}

--- a/backend/src/VeilleBoisee.Infrastructure/Persistence/Configurations/ReportConfiguration.cs
+++ b/backend/src/VeilleBoisee.Infrastructure/Persistence/Configurations/ReportConfiguration.cs
@@ -21,6 +21,9 @@ internal sealed class ReportConfiguration : IEntityTypeConfiguration<Report>
         builder.Property(r => r.ParcelleSection).HasMaxLength(10);
         builder.Property(r => r.ParcelleNumero).HasMaxLength(10);
 
+        builder.Property(r => r.PhotoData).HasColumnType("varbinary(max)");
+        builder.Property(r => r.PhotoMimeType).HasMaxLength(50);
+
         builder.HasIndex(r => r.CommuneInsee);
         builder.HasIndex(r => r.SubmittedAt);
         builder.HasIndex(r => new { r.CommuneInsee, r.SubmittedAt });

--- a/backend/src/VeilleBoisee.Infrastructure/Photos/ImageSharpExifStrippingService.cs
+++ b/backend/src/VeilleBoisee.Infrastructure/Photos/ImageSharpExifStrippingService.cs
@@ -1,0 +1,20 @@
+using SixLabors.ImageSharp;
+using VeilleBoisee.Application.Abstractions;
+
+namespace VeilleBoisee.Infrastructure.Photos;
+
+internal sealed class ImageSharpExifStrippingService : IExifStrippingService
+{
+    public async Task<byte[]> StripExifAsync(Stream photoStream, CancellationToken cancellationToken)
+    {
+        using var image = await Image.LoadAsync(photoStream, cancellationToken);
+
+        image.Metadata.ExifProfile = null;
+        image.Metadata.IptcProfile = null;
+        image.Metadata.XmpProfile = null;
+
+        using var output = new MemoryStream();
+        await image.SaveAsync(output, image.Metadata.DecodedImageFormat!, cancellationToken);
+        return output.ToArray();
+    }
+}

--- a/backend/src/VeilleBoisee.Infrastructure/VeilleBoisee.Infrastructure.csproj
+++ b/backend/src/VeilleBoisee.Infrastructure/VeilleBoisee.Infrastructure.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
     <PackageReference Include="ProjNET" Version="2.1.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/backend/tests/VeilleBoisee.Application.Tests/Fakes/FakeExifStrippingService.cs
+++ b/backend/tests/VeilleBoisee.Application.Tests/Fakes/FakeExifStrippingService.cs
@@ -1,0 +1,13 @@
+using VeilleBoisee.Application.Abstractions;
+
+namespace VeilleBoisee.Application.Tests.Fakes;
+
+internal sealed class FakeExifStrippingService : IExifStrippingService
+{
+    public async Task<byte[]> StripExifAsync(Stream photoStream, CancellationToken cancellationToken)
+    {
+        using var ms = new MemoryStream();
+        await photoStream.CopyToAsync(ms, cancellationToken);
+        return ms.ToArray();
+    }
+}

--- a/backend/tests/VeilleBoisee.Application.Tests/Reports/Commands/SubmitReportHandlerTests.cs
+++ b/backend/tests/VeilleBoisee.Application.Tests/Reports/Commands/SubmitReportHandlerTests.cs
@@ -11,8 +11,9 @@ public class SubmitReportHandlerTests
     private readonly InMemoryReportRepository _repository = new();
     private readonly FakeEmailEncryptionService _encryption = new();
     private readonly FakeGeographicEnrichmentService _enrichment = new();
+    private readonly FakeExifStrippingService _exifStripping = new();
 
-    private SubmitReportHandler CreateHandler() => new(_repository, _encryption, _enrichment);
+    private SubmitReportHandler CreateHandler() => new(_repository, _encryption, _enrichment, _exifStripping);
 
     private static SubmitReportCommand ValidCommand(
         string description = "Décharge de pneus usagés au bord du chemin forestier, quantité importante.",
@@ -166,5 +167,39 @@ public class SubmitReportHandlerTests
 
         // Assert
         _repository.Reports.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Persists_photo_bytes_when_photo_is_provided()
+    {
+        // Arrange
+        var photoBytes = new byte[] { 0xFF, 0xD8, 0xFF };
+        using var photoStream = new MemoryStream(photoBytes);
+        var command = ValidCommand() with { PhotoStream = photoStream, PhotoMimeType = "image/jpeg" };
+
+        // Act
+        var result = await CreateHandler().Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var report = _repository.Reports[0];
+        report.PhotoData.Should().BeEquivalentTo(photoBytes);
+        report.PhotoMimeType.Should().Be("image/jpeg");
+    }
+
+    [Fact]
+    public async Task Persists_no_photo_when_photo_is_not_provided()
+    {
+        // Arrange
+        var command = ValidCommand();
+
+        // Act
+        var result = await CreateHandler().Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var report = _repository.Reports[0];
+        report.PhotoData.Should().BeNull();
+        report.PhotoMimeType.Should().BeNull();
     }
 }

--- a/frontend/src/app/features/dashboard/dashboard-report-api.ts
+++ b/frontend/src/app/features/dashboard/dashboard-report-api.ts
@@ -50,6 +50,7 @@ export interface ReportDetail {
   parcelleNumero: string | null;
   isInForest: boolean | null;
   isInNatura2000Zone: boolean | null;
+  hasPhoto: boolean;
 }
 
 export interface ListFilters {

--- a/frontend/src/app/features/dashboard/report-detail/report-detail.html
+++ b/frontend/src/app/features/dashboard/report-detail/report-detail.html
@@ -28,6 +28,17 @@
           [latitude]="s.report.latitude"
           [longitude]="s.report.longitude" />
 
+        @if (s.report.hasPhoto) {
+          <section class="detail-section detail-section--photo">
+            <h2>Photo</h2>
+            <img
+              [src]="photoUrl(s.report.id)"
+              alt="Photo du dépôt sauvage"
+              class="report-photo"
+            />
+          </section>
+        }
+
         <section class="detail-section">
           <h2>Description</h2>
           <p>{{ s.report.description }}</p>

--- a/frontend/src/app/features/dashboard/report-detail/report-detail.scss
+++ b/frontend/src/app/features/dashboard/report-detail/report-detail.scss
@@ -110,3 +110,19 @@
 
   &--error { color: #842029; }
 }
+
+.detail-section--photo {
+  padding: 0;
+
+  h2 {
+    padding: 1.25rem 1.5rem 0.75rem;
+  }
+}
+
+.report-photo {
+  width: 100%;
+  max-height: 400px;
+  object-fit: contain;
+  background: #f5f5f5;
+  display: block;
+}

--- a/frontend/src/app/features/dashboard/report-detail/report-detail.ts
+++ b/frontend/src/app/features/dashboard/report-detail/report-detail.ts
@@ -10,6 +10,7 @@ import {
   ReportStatus,
 } from '../dashboard-report-api';
 import { ReportMapDisplay } from '../report-map-display/report-map-display';
+import { environment } from '../../../../environments/environment';
 
 type ViewState =
   | { kind: 'loading' }
@@ -66,5 +67,9 @@ export class ReportDetail implements OnInit {
 
   nextStatus(current: ReportStatus): ReportStatus | undefined {
     return this.nextStatuses[current];
+  }
+
+  photoUrl(reportId: string): string {
+    return `${environment.apiBaseUrl}/api/reports/${reportId}/photo`;
   }
 }

--- a/frontend/src/app/features/locate/report-api.ts
+++ b/frontend/src/app/features/locate/report-api.ts
@@ -38,10 +38,20 @@ export class ReportApi {
       );
   }
 
-  submit(request: SubmitReportRequest): Observable<SubmitReportOutcome> {
+  submit(request: SubmitReportRequest, photo: File | null): Observable<SubmitReportOutcome> {
     const url = `${environment.apiBaseUrl}/api/reports`;
+    const formData = new FormData();
+    formData.append('latitude', String(request.latitude));
+    formData.append('longitude', String(request.longitude));
+    formData.append('communeInsee', request.communeInsee);
+    formData.append('communeName', request.communeName);
+    formData.append('description', request.description);
+    formData.append('contactEmail', request.contactEmail);
+    if (photo) {
+      formData.append('photo', photo);
+    }
     return this.http
-      .post<ReportSubmittedResponse>(url, request)
+      .post<ReportSubmittedResponse>(url, formData)
       .pipe(
         map((response): SubmitReportOutcome => ({ status: 'submitted', reportId: response.reportId })),
         catchError((error: HttpErrorResponse): Observable<SubmitReportOutcome> => {

--- a/frontend/src/app/features/locate/report-form/report-form.html
+++ b/frontend/src/app/features/locate/report-form/report-form.html
@@ -43,6 +43,46 @@
     </div>
 
     <div class="field">
+      <label class="field__label">
+        Photo
+        <span class="field__optional">(facultatif)</span>
+      </label>
+      <input
+        #photoInput
+        type="file"
+        accept="image/jpeg,image/png,image/webp"
+        capture="environment"
+        (change)="onPhotoSelected($event)"
+        hidden
+      />
+      @if (!selectedPhoto()) {
+        <button type="button" class="btn btn--secondary" (click)="photoInput.click()">
+          <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+            <circle cx="12" cy="12" r="3.5" stroke="currentColor" stroke-width="1.8" fill="none" />
+            <path
+              d="M9 3H7L5 6H3a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h18a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-2L17 3h-2"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linejoin="round"
+              fill="none"
+            />
+          </svg>
+          Prendre / choisir une photo
+        </button>
+      } @else {
+        <div class="photo-preview">
+          <img [src]="photoPreviewUrl()" alt="Aperçu de la photo" />
+          <button type="button" class="photo-preview__remove" (click)="removePhoto()" aria-label="Supprimer la photo">
+            ✕
+          </button>
+        </div>
+      }
+      @if (photoError()) {
+        <p class="field__error" role="alert">{{ photoError() }}</p>
+      }
+    </div>
+
+    <div class="field">
       <label class="field__label" for="contactEmail">
         E-mail de contact
         <span class="field__required" aria-hidden="true">*</span>

--- a/frontend/src/app/features/locate/report-form/report-form.scss
+++ b/frontend/src/app/features/locate/report-form/report-form.scss
@@ -80,6 +80,13 @@
     margin-inline-start: 2px;
   }
 
+  &__optional {
+    font-weight: 400;
+    color: var(--color-ink-400);
+    margin-inline-start: var(--space-2);
+    font-size: 0.85em;
+  }
+
   &__input,
   &__textarea {
     width: 100%;
@@ -211,6 +218,17 @@
     width: 100%;
   }
 
+  &--secondary {
+    background: var(--color-surface-sunk);
+    color: var(--color-forest-700);
+    border: 1.5px solid var(--color-forest-300);
+
+    &:hover:not(:disabled) {
+      background: var(--color-moss-100);
+      border-color: var(--color-forest-500);
+    }
+  }
+
   &--primary {
     background: var(--color-forest-700);
     color: #fff;
@@ -234,6 +252,45 @@
     border: 2px solid currentColor;
     border-right-color: transparent;
     animation: spin 0.7s linear infinite;
+  }
+}
+
+.photo-preview {
+  position: relative;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--color-surface-sunk);
+
+  img {
+    width: 100%;
+    max-height: 200px;
+    object-fit: cover;
+    display: block;
+  }
+
+  &__remove {
+    position: absolute;
+    top: var(--space-2);
+    right: var(--space-2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    font-size: 0.85rem;
+    font-weight: 700;
+    font-family: inherit;
+    color: #fff;
+    background: var(--color-clay-500);
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    transition: background var(--duration-fast) var(--ease-out);
+
+    &:hover {
+      background: #a03020;
+    }
   }
 }
 

--- a/frontend/src/app/features/locate/report-form/report-form.ts
+++ b/frontend/src/app/features/locate/report-form/report-form.ts
@@ -1,8 +1,11 @@
-import { Component, EventEmitter, Input, Output, inject, signal } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, Output, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 
 import { CommuneResponse } from '../commune-api';
 import { ReportApi, SubmitReportOutcome } from '../report-api';
+
+const MAX_PHOTO_SIZE = 5 * 1024 * 1024;
+const ALLOWED_PHOTO_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
 @Component({
   selector: 'app-report-form',
@@ -10,7 +13,7 @@ import { ReportApi, SubmitReportOutcome } from '../report-api';
   templateUrl: './report-form.html',
   styleUrl: './report-form.scss',
 })
-export class ReportForm {
+export class ReportForm implements OnDestroy {
   @Input({ required: true }) commune!: CommuneResponse;
   @Input({ required: true }) latitude!: number;
   @Input({ required: true }) longitude!: number;
@@ -21,11 +24,42 @@ export class ReportForm {
 
   readonly submitting = signal(false);
   readonly errorMessage = signal<string | null>(null);
+  readonly selectedPhoto = signal<File | null>(null);
+  readonly photoPreviewUrl = signal<string | null>(null);
+  readonly photoError = signal<string | null>(null);
 
   readonly form = this.fb.group({
     description: ['', [Validators.required, Validators.minLength(10), Validators.maxLength(2000)]],
     contactEmail: ['', [Validators.required, Validators.email]],
   });
+
+  onPhotoSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0] ?? null;
+    if (!file) return;
+
+    if (file.size > MAX_PHOTO_SIZE) {
+      this.photoError.set('La photo ne peut pas dépasser 5 Mo.');
+      return;
+    }
+
+    if (!ALLOWED_PHOTO_TYPES.includes(file.type)) {
+      this.photoError.set('Format non supporté. Utilisez JPEG, PNG ou WebP.');
+      return;
+    }
+
+    this.revokePreview();
+    this.photoError.set(null);
+    this.selectedPhoto.set(file);
+    this.photoPreviewUrl.set(URL.createObjectURL(file));
+  }
+
+  removePhoto(): void {
+    this.revokePreview();
+    this.selectedPhoto.set(null);
+    this.photoPreviewUrl.set(null);
+    this.photoError.set(null);
+  }
 
   submit(): void {
     if (this.form.invalid || this.submitting()) return;
@@ -37,14 +71,17 @@ export class ReportForm {
     this.errorMessage.set(null);
 
     this.reportApi
-      .submit({
-        latitude: this.latitude,
-        longitude: this.longitude,
-        communeInsee: this.commune.codeInsee,
-        communeName: this.commune.name,
-        description: this.form.value.description!,
-        contactEmail: this.form.value.contactEmail!,
-      })
+      .submit(
+        {
+          latitude: this.latitude,
+          longitude: this.longitude,
+          communeInsee: this.commune.codeInsee,
+          communeName: this.commune.name,
+          description: this.form.value.description!,
+          contactEmail: this.form.value.contactEmail!,
+        },
+        this.selectedPhoto(),
+      )
       .subscribe((outcome: SubmitReportOutcome) => {
         this.submitting.set(false);
         switch (outcome.status) {
@@ -59,5 +96,14 @@ export class ReportForm {
             break;
         }
       });
+  }
+
+  ngOnDestroy(): void {
+    this.revokePreview();
+  }
+
+  private revokePreview(): void {
+    const url = this.photoPreviewUrl();
+    if (url) URL.revokeObjectURL(url);
   }
 }


### PR DESCRIPTION
Contexte
Un signalement sans photo est difficile à traiter pour une collectivité. Cette PR ajoute la possibilité de joindre une photo (optionnelle) lors de la soumission d'un signalement, avec suppression automatique des métadonnées EXIF avant stockage (RGPD).

Changements
Backend

Entité Report : ajout de PhotoData et PhotoMimeType
SubmitReportCommand + handler : accepte un Stream? photo, délègue la suppression EXIF à IExifStrippingService avant persistance
ReportsController : passe en multipart/form-data, valide la photo côté serveur (limite 5 Mo, formats JPEG/PNG/WebP), ajoute l'endpoint GET /api/reports/{id}/photo
IExifStrippingService : nouveau port dans la couche Application
ImageSharpExifStrippingService : implémentation Infrastructure via ImageSharp
Migration EF Core : AddPhotoToReport
Frontend

Formulaire de signalement : sélection de fichier avec validation (5 Mo, JPEG/PNG/WebP), prévisualisation, nettoyage de l'object URL dans ngOnDestroy
report-api.ts : envoi en FormData (multipart)
Détail d'un signalement : affichage de la photo si présente
Tests

SubmitReportHandlerTests mis à jour avec scénarios photo
FakeExifStrippingService pour les tests unitaires