### PR TITLE
Nettoyer automatiquement les signalements fantômes du localStorage

### DIFF
--- a/frontend/src/app/features/locate/report-api.ts
+++ b/frontend/src/app/features/locate/report-api.ts
@@ -2,9 +2,14 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable, catchError, map, of } from 'rxjs';
 
+import { environment } from '../../../environments/environment';
+
 export type ReportStatus = 'Pending' | 'Routed' | 'Acknowledged' | 'Closed';
 
-import { environment } from '../../../environments/environment';
+export type ReportStatusOutcome =
+  | { kind: 'found'; status: ReportStatus }
+  | { kind: 'not-found' }
+  | { kind: 'error' };
 
 export interface SubmitReportRequest {
   latitude: number;
@@ -28,13 +33,16 @@ export type SubmitReportOutcome =
 export class ReportApi {
   private readonly http = inject(HttpClient);
 
-  getStatus(reportId: string): Observable<ReportStatus | null> {
+  getStatus(reportId: string): Observable<ReportStatusOutcome> {
     const url = `${environment.apiBaseUrl}/api/reports/${reportId}/status`;
     return this.http
-      .get<{ status: ReportStatus }>(url)
+      .get<{ status: ReportStatus }>(url, { headers: { 'Cache-Control': 'no-cache' } })
       .pipe(
-        map((response) => response.status),
-        catchError(() => of(null)),
+        map((response): ReportStatusOutcome => ({ kind: 'found', status: response.status })),
+        catchError((error: HttpErrorResponse): Observable<ReportStatusOutcome> => {
+          if (error.status === 404) return of({ kind: 'not-found' });
+          return of({ kind: 'error' });
+        }),
       );
   }
 

--- a/frontend/src/app/features/my-reports/my-reports.ts
+++ b/frontend/src/app/features/my-reports/my-reports.ts
@@ -2,7 +2,7 @@ import { DatePipe } from '@angular/common';
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
-import { ReportApi, ReportStatus } from '../locate/report-api';
+import { ReportApi, ReportStatus, ReportStatusOutcome } from '../locate/report-api';
 import { SavedReport, SavedReportsService } from './saved-reports.service';
 
 interface DisplayReport extends SavedReport {
@@ -31,13 +31,15 @@ export class MyReports implements OnInit {
   );
 
   ngOnInit(): void {
-    this.reports().forEach((report, index) => {
-      this.reportApi.getStatus(report.id).subscribe((status) => {
-        this.reports.update((list) => {
-          const updated = [...list];
-          updated[index] = { ...updated[index], status };
-          return updated;
-        });
+    this.savedReports.getAll().forEach((report) => {
+      this.reportApi.getStatus(report.id).subscribe((outcome: ReportStatusOutcome) => {
+        if (outcome.kind === 'not-found') {
+          this.savedReports.remove(report.id);
+          this.reports.update((list) => list.filter((r) => r.id !== report.id));
+          return;
+        }
+        const status = outcome.kind === 'found' ? outcome.status : null;
+        this.reports.update((list) => list.map((r) => (r.id === report.id ? { ...r, status } : r)));
       });
     });
   }

--- a/frontend/src/app/features/my-reports/saved-reports.service.ts
+++ b/frontend/src/app/features/my-reports/saved-reports.service.ts
@@ -23,4 +23,8 @@ export class SavedReportsService {
       return [];
     }
   }
+
+  remove(id: string): void {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(this.getAll().filter((r) => r.id !== id)));
+  }
 }


### PR DESCRIPTION
Quand getStatus retourne 404, le rapport n'existe plus côté serveur : on le supprime du localStorage et de l'affichage immédiatement. Les erreurs réseau (500, timeout) conservent le rapport avec statut "…".

- report-api : ReportStatusOutcome discrimine found / not-found / error
  + header Cache-Control: no-cache pour éviter la mise en cache navigateur
- saved-reports.service : ajout de remove(id)
- my-reports : ngOnInit basé sur l'ID au lieu de l'index, suppression sur 404
