### PR TITLE
Ajoute la navigation retour mobile dans le header

### DIFF
--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -3,6 +3,15 @@
 <div class="shell">
   <header class="shell__header">
     <div class="container shell__header-inner">
+      @if (showBackButton()) {
+        <a class="header-back" routerLink="/" aria-label="Retour au menu">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" aria-hidden="true">
+            <path d="M19 12H5M11 6l-6 6 6 6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <span class="header-back__label">Menu</span>
+        </a>
+      }
+
       <a class="brand" routerLink="/" aria-label="Veille Boisée — accueil">
         <span class="brand__mark" aria-hidden="true">
           <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/frontend/src/app/app.scss
+++ b/frontend/src/app/app.scss
@@ -78,6 +78,33 @@
   }
 }
 
+.header-back {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--color-forest-700);
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
+
+  &:hover {
+    background: rgba(31, 61, 43, 0.06);
+    color: var(--color-forest-900);
+  }
+
+  &__label {
+    font-family: var(--font-sans);
+  }
+}
+
 .header-logout {
   display: inline-flex;
   align-items: center;
@@ -143,6 +170,10 @@
 }
 
 @media (min-width: 720px) {
+  .header-back {
+    display: none;
+  }
+
   .shell__header-inner {
     padding-block: var(--space-4);
   }

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit, inject } from '@angular/core';
-import { RouterLink, RouterOutlet } from '@angular/router';
+import { RouterLink, RouterOutlet, Router, NavigationEnd } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { filter, map } from 'rxjs';
 import { MsalService } from '@azure/msal-angular';
 import { AuthService } from './core/auth/auth.service';
 
@@ -11,7 +13,16 @@ import { AuthService } from './core/auth/auth.service';
 })
 export class App implements OnInit {
   private readonly msalService = inject(MsalService);
+  private readonly router = inject(Router);
   readonly auth = inject(AuthService);
+
+  readonly showBackButton = toSignal(
+    this.router.events.pipe(
+      filter((e) => e instanceof NavigationEnd),
+      map((e) => (e as NavigationEnd).urlAfterRedirects !== '/'),
+    ),
+    { initialValue: this.router.url !== '/' },
+  );
 
   ngOnInit(): void {
     this.msalService.initialize().subscribe(() => {


### PR DESCRIPTION
Un lien "← Menu" apparaît dans le header sur mobile (< 720px) dès que l'utilisateur quitte la page d'accueil. Le signal showBackButton réagit aux événements NavigationEnd du router pour masquer / afficher le lien sans rechargement de page.

