### PR TITLE
Déplace le lien retour en dessous du header

### DIFF
--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -3,40 +3,30 @@
 <div class="shell">
   <header class="shell__header">
     <div class="container shell__header-inner">
-      <div class="shell__header-start">
-        @if (showBackButton()) {
-          <a class="header-back" routerLink="/" aria-label="Retour au menu">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" aria-hidden="true">
-              <path d="M19 12H5M11 6l-6 6 6 6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </a>
-        }
-
-        <a class="brand" routerLink="/" aria-label="Veille Boisée — accueil">
-          <span class="brand__mark" aria-hidden="true">
-            <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path
-                d="M16 3c-5.5 4-9 8.5-9 14 0 4.3 2.7 7.8 6.5 9v3h5v-3c3.8-1.2 6.5-4.7 6.5-9 0-5.5-3.5-10-9-14z"
-                fill="currentColor"
-                opacity="0.95"
-              />
-              <path
-                d="M16 7v19"
-                stroke="#faf7f0"
-                stroke-width="1.2"
-                stroke-linecap="round"
-              />
-              <path
-                d="M16 14c-1.8-1-3.2-1.6-5-1.8M16 18c-2-1-3.6-1.5-5.5-1.7M16 14c1.8-1 3.2-1.6 5-1.8M16 18c2-1 3.6-1.5 5.5-1.7"
-                stroke="#faf7f0"
-                stroke-width="1.2"
-                stroke-linecap="round"
-              />
-            </svg>
-          </span>
-          <span class="brand__name">Veille Boisée</span>
-        </a>
-      </div>
+      <a class="brand" routerLink="/" aria-label="Veille Boisée — accueil">
+        <span class="brand__mark" aria-hidden="true">
+          <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M16 3c-5.5 4-9 8.5-9 14 0 4.3 2.7 7.8 6.5 9v3h5v-3c3.8-1.2 6.5-4.7 6.5-9 0-5.5-3.5-10-9-14z"
+              fill="currentColor"
+              opacity="0.95"
+            />
+            <path
+              d="M16 7v19"
+              stroke="#faf7f0"
+              stroke-width="1.2"
+              stroke-linecap="round"
+            />
+            <path
+              d="M16 14c-1.8-1-3.2-1.6-5-1.8M16 18c-2-1-3.6-1.5-5.5-1.7M16 14c1.8-1 3.2-1.6 5-1.8M16 18c2-1 3.6-1.5 5.5-1.7"
+              stroke="#faf7f0"
+              stroke-width="1.2"
+              stroke-linecap="round"
+            />
+          </svg>
+        </span>
+        <span class="brand__name">Veille Boisée</span>
+      </a>
 
       @if (auth.isAuthenticated()) {
         <button class="header-logout" (click)="auth.logout()" type="button">
@@ -49,6 +39,19 @@
       }
     </div>
   </header>
+
+  @if (showBackButton()) {
+    <nav class="shell__back-nav" aria-label="Retour">
+      <div class="container">
+        <a class="back-link" routerLink="/">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" aria-hidden="true">
+            <path d="M19 12H5M11 6l-6 6 6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          Accueil
+        </a>
+      </div>
+    </nav>
+  }
 
   <main id="main" class="shell__main">
     <router-outlet />

--- a/frontend/src/app/app.scss
+++ b/frontend/src/app/app.scss
@@ -78,32 +78,27 @@
   }
 }
 
-.shell__header-start {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-3);
+.shell__back-nav {
+  border-bottom: 1px solid rgba(31, 61, 43, 0.07);
+  background: rgba(232, 239, 224, 0.35);
+
+  @media (min-width: 720px) {
+    display: none;
+  }
 }
 
-.header-back {
+.back-link {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: 34px;
-  height: 34px;
-  background: var(--color-moss-100);
-  border: none;
-  border-radius: var(--radius-md);
-  box-shadow: inset 0 0 0 1px rgba(31, 61, 43, 0.1);
+  gap: var(--space-2);
+  padding-block: var(--space-2);
+  font-size: 0.8rem;
+  font-weight: 500;
   color: var(--color-forest-700);
   text-decoration: none;
-  cursor: pointer;
-  transition:
-    background var(--duration-fast) var(--ease-out),
-    color var(--duration-fast) var(--ease-out);
+  letter-spacing: 0.01em;
 
   &:hover {
-    background: var(--color-moss-200);
     color: var(--color-forest-900);
   }
 }
@@ -173,10 +168,6 @@
 }
 
 @media (min-width: 720px) {
-  .header-back {
-    display: none;
-  }
-
   .shell__header-inner {
     padding-block: var(--space-4);
   }


### PR DESCRIPTION
La flèche "← Accueil" passe dans une fine barre shell__back-nav entre le header et le contenu, visible uniquement sur mobile. Le header retrouve sa structure d'origine (logo seul à gauche).

