### PR TITLE
Add missing API token to Azure Static Web Apps close action

### DIFF
--- a/.github/workflows/azure-static-web-apps-black-moss-0334f9d03.yml
+++ b/.github/workflows/azure-static-web-apps-black-moss-0334f9d03.yml
@@ -55,4 +55,5 @@ jobs:
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1
         with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BLACK_MOSS_0334F9D03 }}
           action: "close"


### PR DESCRIPTION
## Description
Adds the missing `azure_static_web_apps_api_token` secret to the close pull request step in the Azure Static Web Apps deployment workflow. This token is required by the Azure/static-web-apps-deploy action to properly authenticate and close preview environments when pull requests are closed.

## Issue liée
<!-- If there's a related issue, reference it here -->

## Checklist

### Code
- [x] No unit tests needed (workflow configuration change)
- [x] No linting issues
- [x] No dead code introduced
- [x] No unnecessary comments

### Sécurité
- [x] Secret properly stored in GitHub secrets (not hardcoded)
- [x] No user input validation needed (workflow configuration)
- [x] No new endpoints exposed

### RGPD
- [x] No personal data involved
- [x] No RGPD documentation updates needed

https://claude.ai/code/session_0182KU21m21StRW4iMJqFtdp