### PR TITLE
Corrige les jobs GitHub Actions Azure Static Web Apps

### DIFF
--- a/.github/workflows/azure-static-web-apps-black-moss-0334f9d03.yml
+++ b/.github/workflows/azure-static-web-apps-black-moss-0334f9d03.yml
@@ -15,36 +15,21 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     permissions:
-       id-token: write
-       contents: read
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           lfs: false
-      - name: Install OIDC Client from Core Package
-        run: npm install @actions/core@1.6.0 @actions/http-client
-      - name: Get Id Token
-        uses: actions/github-script@v6
-        id: idtoken
-        with:
-           script: |
-               const coredemo = require('@actions/core')
-               return await coredemo.getIDToken()
-           result-encoding: string
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BLACK_MOSS_0334F9D03 }}
           action: "upload"
-          ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
-          # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "./frontend" # App source code path
-          api_location: "" # Api source code path - optional
-          output_location: "dist/frontend/browser" # Built app content directory - optional
-          github_id_token: ${{ steps.idtoken.outputs.result }}
-          ###### End of Repository/Build Configurations ######
+          app_location: "./frontend"
+          api_location: ""
+          output_location: "dist/frontend/browser"
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'


### PR DESCRIPTION
## Résumé

- **Close Pull Request Job** : token `azure_static_web_apps_api_token` manquant — le job échouait à chaque merge de PR
- **Build and Deploy Job** : séquence OIDC fragile (`Install OIDC Client` + `Get Id Token` via `actions/github-script@v6`) qui annulait le job avant d'atteindre le build, probablement suite à une mise à jour du runner GitHub Actions

## Corrections

- Suppression des étapes OIDC inutiles (`npm install @actions/core`, `Get Id Token`, `github_id_token`) — le token statique `azure_static_web_apps_api_token` suffit
- Ajout du token manquant dans `close_pull_request_job`
- `actions/checkout@v3` → `v4`
- Suppression de la permission `id-token: write` devenue inutile

## Plan de test

- [ ] Vérifier que le job **Build and Deploy Job** passe au vert sur cette PR
- [ ] Merger la PR et vérifier que le job **Close Pull Request Job** passe au vert

https://claude.ai/code/session_0182KU21m21StRW4iMJqFtdp

---
_Generated by [Claude Code](https://claude.ai/code/session_0182KU21m21StRW4iMJqFtdp)_