### PR TITLE
Correction de l'invite de permission GPS manquante

### DIFF
--- a/frontend/src/app/features/locate/locate/locate.html
+++ b/frontend/src/app/features/locate/locate/locate.html
@@ -57,7 +57,15 @@
       @case ('geolocationDenied') {
         <div class="status status--warning">
           <span class="status__icon" aria-hidden="true">!</span>
-          <span>Accès à la position refusé. Autorisez-la dans les paramètres du navigateur.</span>
+          <div class="status__body">
+            <p>L'accès à la position a été refusé.</p>
+            @if (isStandalonePwa) {
+              <p>Ouvrez les <strong>Paramètres</strong> de votre téléphone, puis allez dans <strong>Applications</strong>, cherchez l'application, et autorisez la <strong>Localisation</strong>.</p>
+            } @else {
+              <p>Appuyez sur l'icône de cadenas dans la barre d'adresse, puis autorisez la <strong>Localisation</strong> pour ce site.</p>
+            }
+            <button type="button" class="btn btn--secondary" (click)="useCurrentPosition()">Réessayer</button>
+          </div>
         </div>
       }
       @case ('geolocationInsecureContext') {

--- a/frontend/src/app/features/locate/locate/locate.scss
+++ b/frontend/src/app/features/locate/locate/locate.scss
@@ -120,7 +120,7 @@
 
 .status {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--space-3);
   padding: var(--space-4);
   border-radius: var(--radius-md);
@@ -135,6 +135,7 @@
     border-right-color: transparent;
     animation: spin 0.7s linear infinite;
     flex-shrink: 0;
+    margin-top: 2px;
   }
 
   &__icon {
@@ -153,6 +154,18 @@
 
   & > span:last-child {
     color: var(--color-ink-900);
+    margin-top: 1px;
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+
+    p {
+      margin: 0;
+      color: var(--color-ink-900);
+    }
   }
 
   &--loading {

--- a/frontend/src/app/features/locate/locate/locate.ts
+++ b/frontend/src/app/features/locate/locate/locate.ts
@@ -27,6 +27,7 @@ export class Locate {
   private readonly communeApi = inject(CommuneApi);
 
   readonly state = signal<ViewState>({ kind: 'idle' });
+  readonly isStandalonePwa = window.matchMedia('(display-mode: standalone)').matches;
 
   onCoordinatesPicked(coords: PickedCoordinates): void {
     this.queryCommune(coords.latitude, coords.longitude);
@@ -43,6 +44,23 @@ export class Locate {
       return;
     }
 
+    if (navigator.permissions) {
+      navigator.permissions
+        .query({ name: 'geolocation' })
+        .then((permissionStatus) => {
+          if (permissionStatus.state === 'denied') {
+            this.state.set({ kind: 'geolocationDenied' });
+          } else {
+            this.requestPosition();
+          }
+        })
+        .catch(() => this.requestPosition());
+    } else {
+      this.requestPosition();
+    }
+  }
+
+  private requestPosition(): void {
     navigator.geolocation.getCurrentPosition(
       (position) => {
         const { latitude, longitude } = position.coords;


### PR DESCRIPTION
Quand la permission de géolocalisation était déjà refusée dans le navigateur,
l'appel à getCurrentPosition échouait silencieusement (aucune invite affichée).

On consulte désormais l'API Permissions avant d'appeler getCurrentPosition :
si l'état est 'denied', l'erreur s'affiche immédiatement sans round-trip inutile.

Le message d'erreur est enrichi avec des instructions contextuelles (différentes
selon que l'appli est ouverte en PWA standalone ou dans le navigateur) et un
bouton « Réessayer » permettant de relancer la demande après avoir corrigé le
paramétrage.

https://claude.ai/code/session_01JKC6Zx8tVNVBHddWdXfm7C